### PR TITLE
Add vscode-java OpenShift AI workbench image

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,11 @@
+---
+extends: default
+rules:
+  line-length: disable
+  document-start: disable
+  indentation:
+    indent-sequences: whatever
+  hyphens:
+    max-spaces-after: 4
+  truthy:
+    check-keys: false

--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 # NERC Container Images
 
 Below is an overview, technical information, installed packages, and how to get each image below.
+
+| NERC Container Images | Description |
+| --- | --- |
+| [vscode-java](https://github.com/nerc-images/vscode-java) | An OpenShift AI Image running VSCode for Java development. |

--- a/imagestreams/vscode-java/imagestream.yaml
+++ b/imagestreams/vscode-java/imagestream.yaml
@@ -1,0 +1,32 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: vscode-java
+  namespace: redhat-ods-applications
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: >-
+      https://github.com/nerc-images/vscode-java
+    opendatahub.io/notebook-image-name: >-
+      VSCode IJava java-17-openjdk
+    opendatahub.io/notebook-image-desc: >-
+      An OpenShift AI Image for Java development.
+      Based on IJava project by SpencerPark on GitHub for Jupyter
+      Lab Notebook integration.  Uses java-17-openjdk-devel and
+      maven package support.  Used by the Smarta Byar Smart Village
+      Community using AI/ML code generation technology for Smart
+      Data Model APIs.
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: latest
+      annotations: null
+      from:
+        kind: DockerImage
+        name: 'ghcr.io/nerc-images/vscode-java:main'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Source

--- a/imagestreams/vscode-java/kustomization.yaml
+++ b/imagestreams/vscode-java/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagestream.yaml

--- a/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../imagestreams/vscode-java


### PR DESCRIPTION
Add vscode-java OpenShift AI workbench image. Based on the IJava project by SpencerPark for Jupyter Lab Notebook integration.  Uses java-17-openjdk-devel and maven package support.
