### PR TITLE
support for Java and C++ in VSCode and Jupyter into OpenShift AI

### DIFF
--- a/imagestreams/jupyter-cpp-cling/imagestream.yaml
+++ b/imagestreams/jupyter-cpp-cling/imagestream.yaml
@@ -1,0 +1,32 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: jupyter-cpp-cling
+  namespace: redhat-ods-applications
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: >-
+      https://github.com/nerc-images/jupyter-cpp-cling
+    opendatahub.io/notebook-image-name: >-
+      Jupyter C++ Cling
+    opendatahub.io/notebook-image-desc: >-
+      An OpenShift AI Image running Jupyter Lab for C++ development.
+      - Based on the [Xeus Cling project](https://github.com/jupyter-xeus/xeus-cling)
+      on GitHub for Jupyter Lab Notebook integration.
+      - Uses C++ Kernel 11, 14, and 17 and gcc-c++ compiler support.
+      - Used by Professor Leonidas Kontothanassis, MassMutual Professor of the
+      Practice of Computing & Data Sciences + Director of Industry Engagement.
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: 1.0.0
+      annotations: null
+      from:
+        kind: DockerImage
+        name: 'quay.io/nerc-images/jupyter-cpp-cling:1.0.0'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Source

--- a/imagestreams/jupyter-cpp-cling/kustomization.yaml
+++ b/imagestreams/jupyter-cpp-cling/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagestream.yaml

--- a/imagestreams/vscode-cpp-cling/imagestream.yaml
+++ b/imagestreams/vscode-cpp-cling/imagestream.yaml
@@ -1,0 +1,32 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: vscode-cpp-cling
+  namespace: redhat-ods-applications
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: >-
+      https://github.com/nerc-images/vscode-cpp-cling
+    opendatahub.io/notebook-image-name: >-
+      VSCode C++ Cling
+    opendatahub.io/notebook-image-desc: >-
+      An OpenShift AI Image running VSCode for C++ development.
+      - Based on the [Xeus Cling project](https://github.com/jupyter-xeus/xeus-cling)
+      on GitHub for Jupyter Lab Notebook integration.
+      - Uses C++ Kernel 11, 14, and 17 and gcc-c++ compiler support.
+      - Used by Professor Leonidas Kontothanassis, MassMutual Professor of the
+      Practice of Computing & Data Sciences + Director of Industry Engagement.
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: 1.0.0
+      annotations: null
+      from:
+        kind: DockerImage
+        name: 'quay.io/nerc-images/vscode-cpp-cling:1.0.0'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Source

--- a/imagestreams/vscode-cpp-cling/kustomization.yaml
+++ b/imagestreams/vscode-cpp-cling/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagestream.yaml

--- a/imagestreams/vscode-java/imagestream.yaml
+++ b/imagestreams/vscode-java/imagestream.yaml
@@ -21,11 +21,11 @@ spec:
   lookupPolicy:
     local: true
   tags:
-    - name: latest
+    - name: 1.0.0
       annotations: null
       from:
         kind: DockerImage
-        name: 'ghcr.io/nerc-images/vscode-java:main'
+        name: 'quay.io/nerc-images/vscode-java:1.0.0'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/overlays/nerc-ocp-prod/kustomization.yaml
@@ -2,3 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../imagestreams/vscode-java
+  - ../../imagestreams/jupyter-cpp-cling
+  - ../../imagestreams/vscode-cpp-cling


### PR DESCRIPTION
- **Add vscode-java OpenShift AI workbench image**
- **Moving openshift-ai image builds to quay.io**
