### PR TITLE
Adding missing links to images in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,6 @@ Below is an overview, technical information, installed packages, and how to get 
 
 | NERC Container Images | Description |
 | --- | --- |
+| [jupyter-cpp-cling](https://github.com/nerc-images/jupyter-cpp-cling) | An OpenShift AI Image running Jupyter Lab for C++ development. |
+| [vscode-cpp-cling](https://github.com/nerc-images/vscode-cpp-cling) | An OpenShift AI Image running VSCode for C++ development. |
 | [vscode-java](https://github.com/nerc-images/vscode-java) | An OpenShift AI Image running VSCode for Java development. |


### PR DESCRIPTION
Adding the missing documentation links for the vscode-cpp-cling and
jupyter-cpp-cling image.
