### PR TITLE
Use the latest 1.2.0 release of vscode-java

### DIFF
--- a/imagestreams/vscode-java/imagestream.yaml
+++ b/imagestreams/vscode-java/imagestream.yaml
@@ -21,11 +21,11 @@ spec:
   lookupPolicy:
     local: true
   tags:
-    - name: 1.0.0
+    - name: 1.2.0
       annotations: null
       from:
         kind: DockerImage
-        name: 'quay.io/nerc-images/vscode-java:1.0.0'
+        name: 'quay.io/nerc-images/vscode-java:1.2.0'
       importPolicy:
         scheduled: true
       referencePolicy:


### PR DESCRIPTION
To update the vscode-java tag to 1.2.0 for the OpenShift AI vscode-java image in NERC.