### PR TITLE
Added recommended accelerators to openad_workbench

### DIFF
--- a/imagestreams/openad_workbench/imagestream.yaml
+++ b/imagestreams/openad_workbench/imagestream.yaml
@@ -12,6 +12,8 @@ metadata:
       OpenAD Workbench
     opendatahub.io/notebook-image-desc: >-
       A Jupyter OpenShift AI Image with OpenAD for GPUs.
+    opendatahub.io/recommended-accelerators: >-
+      ["nvidia.com/gpu"]
 spec:
   lookupPolicy:
     local: true


### PR DESCRIPTION
To make RHOAI's UI happier, the recommended accelerators tag was added to the openad_workbench image