### PR TITLE
Switch base image to new VSCode provided by OpenShift

### DIFF
--- a/imagestreams/vscode-java/imagestream.yaml
+++ b/imagestreams/vscode-java/imagestream.yaml
@@ -21,11 +21,11 @@ spec:
   lookupPolicy:
     local: true
   tags:
-    - name: 1.3.0
+    - name: 1.4.0
       annotations: null
       from:
         kind: DockerImage
-        name: 'quay.io/nerc-images/vscode-java:1.3.0'
+        name: 'quay.io/nerc-images/vscode-java:1.4.0'
       importPolicy:
         scheduled: true
       referencePolicy:


### PR DESCRIPTION
OpenShift is now offering a VSCode OpenShift AI Workbench Image from
quay.io/modh/codeserver: 

```bash
$ oc --as system:admin -n redhat-ods-applications get imagestream/code-server-notebook -o yaml | grep '  from:' -A 2
    from:
      kind: DockerImage
      name: quay.io/modh/codeserver@sha256:575df4c8ce5bfb2c6dc355fcae74e0cc7499e0490f4d9deeb9788fe3aaa7f6d1
```

so we will use that instead. 

This new image uses an up-to-date `code-server: v4.92.2` and `Code: 1.92.2` 

versus `code-server: v4.16.1` and `Code: 1.80.2` in the old image. 

Thanks @Milstein for the suggestion! 
