### PR TITLE
Update AltaStata image to use AMD64-specific tag

### DIFF
--- a/imagestreams/altastata-jupyter-datascience/imagestream.yaml
+++ b/imagestreams/altastata-jupyter-datascience/imagestream.yaml
@@ -22,7 +22,7 @@ spec:
       annotations: null
       from:
         kind: DockerImage
-        name: 'ghcr.io/sergevil/altastata/jupyter-datascience:2025a_latest'
+        name: 'ghcr.io/sergevil/altastata/jupyter-datascience-amd64:2025a_latest'
       importPolicy:
         scheduled: true
       referencePolicy:


### PR DESCRIPTION
This PR updates the AltaStata Jupyter DataScience image stream to use the AMD64-specific tag.

## Changes
- Updated image source from  to 
- This ensures the image stream uses the AMD64 architecture-specific version of the image

## Files Modified
-  - Updated image source URL