### PR TITLE
Update AltaStata image to 2025b_latest tag

### DIFF
--- a/imagestreams/altastata-jupyter-datascience/imagestream.yaml
+++ b/imagestreams/altastata-jupyter-datascience/imagestream.yaml
@@ -18,11 +18,11 @@ spec:
   lookupPolicy:
     local: true
   tags:
-    - name: 2025a_latest
+    - name: 2025b_latest
       annotations: null
       from:
         kind: DockerImage
-        name: 'ghcr.io/sergevil/altastata/jupyter-datascience-amd64:2025a_latest'
+        name: 'ghcr.io/sergevil/altastata/jupyter-datascience:2025b_latest'
       importPolicy:
         scheduled: true
       referencePolicy:


### PR DESCRIPTION
This PR updates the AltaStata Jupyter DataScience image stream to use the 2025b_latest tag.

## Changes
- Updated image tag from  to 
- Updated image source from  to 
- This updates the image stream to use the latest 2025b version of the AltaStata image

## Files Modified
-  - Updated tag and image source URL