### PR TITLE
add pytorch with nglview imagestream

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ Below is an overview, technical information, installed packages, and how to get 
 | [odh-tec](https://github.com/rh-aiservices-bu/odh-tec/) | Open Data Hub Tools & Extensions Companion (ODH-TEC) is a unified storage tool enabling seamless file management across Open Data Hub, Red Hat OpenShift AI, and Podman using S3 and local storage. |
 | [base-ope-image](https://github.com/nerc-images/base-ope-image) | An OpenShift AI Image that has the basic Jupyter Notebook UI. |
 | [ucsls-F24](https://github.com/nerc-images/ucsls-F24) | An OpenShift AI Image designed for courses, speficially the Boston University class CS210. |
+| [pytorch-nglview](https://github.com/memalhot/pytorch-nglview/tree/ngl) | An Openshift AI image built on the pytorch image for computational biology and chemistry visualizations with nglview. |

--- a/imagestreams/pytorch-nglview/imagestream.yaml
+++ b/imagestreams/pytorch-nglview/imagestream.yaml
@@ -1,0 +1,26 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: pytorch-ngl
+  namespace: redhat-ods-applications
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-name: "Pytorch with nglview"
+    opendatahub.io/notebook-image-desc: >-
+      Jupyter notebook image for OpenShift AI with PyTorch, CUDA tooling,
+      bash kernel, and nglview support to interactively view molecular structures and trajectories.
+    opendatahub.io/notebook-image-url: >-
+      https://quay.io/nerc-images/pytorch-ngl
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: ngl
+      from:
+        kind: DockerImage
+        name: quay.io/nerc-images/pytorch-ngl:ngl
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Local

--- a/imagestreams/pytorch-nglview/kustomization.yaml
+++ b/imagestreams/pytorch-nglview/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagestream.yaml

--- a/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/overlays/nerc-ocp-prod/kustomization.yaml
@@ -21,3 +21,4 @@ resources:
   - ../../imagestreams/odh-tec
   - ../../imagestreams/base-ope-image
   - ../../imagestreams/ucsls-f24
+  - ../../imagestreams/pytorch-nglview


### PR DESCRIPTION
MOC user doing biology research needed nglview on their pytorch image to visualize compounds.